### PR TITLE
refactor(command-store): lower `loadAll` method complexity

### DIFF
--- a/src/lib/structures/stores/command-store.ts
+++ b/src/lib/structures/stores/command-store.ts
@@ -13,6 +13,7 @@ import { ApplicationCommandOptionType } from "discord-api-types/v10";
 import type { FileMetadata, NamedStoreOptions } from "~/lib/structures/store.js";
 import { Store } from "~/lib/structures/store.js";
 import { Command } from "~/lib/structures/bases/command.js";
+import type { CommandOptionData } from "~/lib/interfaces/command-options.js";
 
 export class CommandStore extends Store<Command> {
     private readonly _commands = new Map<string, ChatInputApplicationCommandData>();
@@ -65,108 +66,111 @@ export class CommandStore extends Store<Command> {
         await super.loadAll();
 
         for (const meta of this.metas) {
-            const {
-                path,
-                root,
-                class: { description, options, defaultMemberPermissions, allowDM }
-            } = meta;
-
-            const directories = relative(root, path).split(sep).slice(0, -1);
-            const fileName = basename(path, extname(path));
-
-            switch (directories.length) {
-                case 0: {
-                    // COMMAND
-                    this._commands.set(fileName, {
-                        name: fileName,
-                        description,
-                        defaultMemberPermissions: defaultMemberPermissions ?? null,
-                        ...(options.length > 0 ? { options: [...options] } : {}),
-                        ...(typeof allowDM === "undefined" || allowDM ? {} : { dmPermission: false })
-                    });
-                    break;
-                }
-
-                case 1: {
-                    // SUB_COMMAND
-                    const [commandName] = directories;
-                    if (!commandName) throw new Error("Sum Ting Wong");
-
-                    const command: ChatInputApplicationCommandData = this._commands.get(commandName) ?? {
-                        name: commandName,
-                        description: commandName.toUpperCase(),
-                        options: []
-                    };
-
-                    if (command.options?.find((opt) => opt.name === fileName))
-                        throw new Error("Sub-command already exists");
-
-                    command.options?.push({
-                        name: fileName,
-                        type: ApplicationCommandOptionType.Subcommand,
-                        description,
-                        ...(options.length > 0 ? { options: [...options] } : {})
-                    });
-
-                    this._commands.set(commandName, command);
-                    break;
-                }
-
-                case 2: {
-                    // SUB_COMMAND_GROUP
-                    const [commandName, subcommandGroupName] = directories;
-                    if (!commandName || !subcommandGroupName) throw new Error("Wi To Lo");
-
-                    const command: ChatInputApplicationCommandData = this._commands.get(commandName) ?? {
-                        name: commandName,
-                        description: commandName.toUpperCase(),
-                        options: []
-                    };
-
-                    const subcommandGroup = command.options?.find((opt) => opt.name === subcommandGroupName);
-
-                    if (subcommandGroup) {
-                        if (subcommandGroup.type !== ApplicationCommandOptionType.SubcommandGroup)
-                            throw new Error("The name for this subcommand group is already taken.");
-
-                        if (subcommandGroup.options?.find((opt) => opt.name === fileName))
-                            throw new Error("Sub-command already exists");
-
-                        subcommandGroup.options?.push({
-                            name: fileName,
-                            type: ApplicationCommandOptionType.Subcommand,
-                            description,
-                            ...(options.length > 0 ? { options: [...options] } : {})
-                        });
-                    } else {
-                        command.options?.push({
-                            name: subcommandGroupName,
-                            type: ApplicationCommandOptionType.SubcommandGroup,
-                            description: subcommandGroupName.toUpperCase(),
-                            options: [
-                                {
-                                    name: fileName,
-                                    type: ApplicationCommandOptionType.Subcommand,
-                                    description,
-                                    ...(options.length > 0 ? { options: [...options] } : {})
-                                }
-                            ]
-                        });
-                    }
-
-                    this._commands.set(commandName, command);
-                    break;
-                }
-
-                default: {
-                    throw new Error("Too much depth");
-                }
-            }
+            const command = this.resolveCommand(meta);
+            this._commands.set(command.name, command);
         }
     }
 
     protected override async insert(metadata: FileMetadata<Command>): Promise<void> {
         return super.insert(metadata);
+    }
+
+    private resolveCommand(meta: FileMetadata<Command>): ChatInputApplicationCommandData {
+        const {
+            path,
+            root,
+            class: { description, options, defaultMemberPermissions, allowDM }
+        } = meta;
+        const directories = relative(root, path).split(sep).slice(0, -1);
+        const fileName = basename(path, extname(path));
+
+        switch (directories.length) {
+            // COMMAND
+            case 0: {
+                return {
+                    name: fileName,
+                    description,
+                    defaultMemberPermissions: defaultMemberPermissions ?? null,
+                    ...(options.length > 0 ? { options: options as CommandOptionData[] } : undefined),
+                    ...(typeof allowDM !== "undefined" && !allowDM ? { dmPermission: false } : undefined)
+                };
+            }
+
+            // SUB-COMMAND
+            case 1: {
+                const [commandName] = directories as [string];
+
+                const command = this._commands.get(commandName) ?? {
+                    name: commandName,
+                    description: commandName.toUpperCase(),
+                    options: []
+                };
+
+                if (command.options?.find((opt) => opt.name === fileName))
+                    throw new Error(`Command '${relative(root, path)}' is already defined in another file`);
+
+                command.options?.push({
+                    name: fileName,
+                    type: ApplicationCommandOptionType.Subcommand,
+                    description,
+                    ...(options.length > 0 ? { options: options as CommandOptionData[] } : undefined)
+                });
+
+                return command;
+            }
+
+            // SUB-COMMAND GROUP
+            case 2: {
+                const [commandName, groupName] = directories as [string, string];
+
+                const command = this._commands.get(commandName) ?? {
+                    name: commandName,
+                    description: commandName.toUpperCase(),
+                    options: []
+                };
+
+                const group = command.options?.find((opt) => opt.name === groupName);
+
+                if (group) {
+                    if (
+                        group.type !== ApplicationCommandOptionType.SubcommandGroup ||
+                        group.options?.find((opt) => opt.name === fileName)
+                    )
+                        throw new Error(
+                            `Command '${relative(root, path)}' is already defined in another file`
+                        );
+
+                    group.options?.push({
+                        name: fileName,
+                        type: ApplicationCommandOptionType.Subcommand,
+                        description,
+                        ...(options.length > 0 ? { options: options as CommandOptionData[] } : undefined)
+                    });
+                } else {
+                    command.options?.push({
+                        name: groupName,
+                        type: ApplicationCommandOptionType.SubcommandGroup,
+                        description: groupName.toUpperCase(),
+                        options: [
+                            {
+                                name: fileName,
+                                type: ApplicationCommandOptionType.Subcommand,
+                                description,
+                                ...(options.length > 0
+                                    ? { options: options as CommandOptionData[] }
+                                    : undefined)
+                            }
+                        ]
+                    });
+                }
+
+                return command;
+            }
+
+            default: {
+                throw new Error(`Invalid command folder structure, max depth reached.`);
+            }
+        }
     }
 
     private async registerCommand(


### PR DESCRIPTION
This PR lowers the code complexity of `CommandStore#loadAll` method by extracting it to the newly created `resolveCommand` method.