### PR TITLE
refactor(logger): simplify initialization and reduce envs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+BOT_TOKEN="<BOT_TOKEN>"
+NODE_ENV="development"
+DEV_GUILD_ID="<GUILD_ID>"

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ yarn-error.log*
 .pnpm-error.log*
 *.log
 
-!.env.example
 .env*
+!.env.example

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ import { IntentsBitField, Partials } from "discord.js";
 import { TronClient } from "~/lib/tron-client.js";
 
 const bot = new TronClient({
-    log_level: process.env.LOG_LEVEL,
     intents: [
         IntentsBitField.Flags.Guilds,
         IntentsBitField.Flags.GuildMembers,

--- a/src/lib/structures/logger.ts
+++ b/src/lib/structures/logger.ts
@@ -4,6 +4,7 @@
  * MIT Licensed
  */
 
+import process from "node:process";
 import { createLogger, Logger as WinstonLogger, transports } from "winston";
 import { elegantFormat, LABEL } from "@zakku/winston-logs";
 import { Injectable } from "~/lib/decorators/injectable.js";
@@ -12,14 +13,10 @@ import { Injectable } from "~/lib/decorators/injectable.js";
 export class Logger {
     logger: WinstonLogger;
 
-    constructor();
-    constructor(level: string);
-    constructor(level: string, label: string | string[]);
-    constructor(level?: string, label?: string | string[]) {
+    constructor(label?: string | string[]) {
         this.logger = createLogger({
-            level: level?.toLowerCase() ?? "info",
+            level: process.env.NODE_ENV === "production" ? "info" : "trace",
             levels: { fatal: 0, error: 1, warn: 2, info: 3, debug: 4, trace: 5 },
-            // TODO: Implement LOG_TYPE env usage, by adding json output
             format: elegantFormat({
                 colors: {
                     trace: "magenta"
@@ -28,7 +25,6 @@ export class Logger {
                     1: "magenta"
                 }
             }),
-            // TODO: Implement output to log management services
             transports: [new transports.Console()],
             ...(label === undefined ? {} : { defaultMeta: { [LABEL]: label } })
         });
@@ -119,6 +115,6 @@ export class Logger {
     }
 
     public createLabeled(label: string | string[]): Logger {
-        return new Logger(this.logger.level, label);
+        return new Logger(label);
     }
 }

--- a/src/lib/tron-client.ts
+++ b/src/lib/tron-client.ts
@@ -17,18 +17,12 @@ import { Logger } from "~/lib/structures/logger.js";
 import { StoreRegistry } from "~/lib/structures/store-registry.js";
 import { CommandStore } from "~/lib/structures/stores/command-store.js";
 
-interface TronClientOptions {
-    log_level?: string | undefined;
-}
-
 declare module "discord.js" {
     interface Client {
         readonly logger: Logger;
         readonly container: interfaces.Container;
         readonly stores: StoreRegistry;
     }
-
-    interface ClientOptions extends TronClientOptions {}
 }
 
 @Injectable
@@ -40,7 +34,7 @@ export class TronClient extends Client {
     constructor(options: ClientOptions) {
         super(options);
 
-        this.logger = new Logger(options.log_level ?? "info");
+        this.logger = new Logger();
         this.container = new Container({ defaultScope: "Singleton" });
 
         // Bind TronClient to the container

--- a/typings/process.d.ts
+++ b/typings/process.d.ts
@@ -9,8 +9,6 @@ declare module "process" {
         namespace NodeJS {
             interface ProcessEnv extends Dict<string> {
                 BOT_TOKEN: string;
-                LOG_LEVEL?: string;
-                LOG_TYPE?: "JSON" | "CONSOLE";
                 NODE_ENV?: "development" | "production";
                 DEV_GUILD_ID?: string;
             }


### PR DESCRIPTION
This PR simplifies `Logger` initialization and reduces the amount of required envs for the app to start.