### PR TITLE
feat: unregister commands on file deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "preinstall": "npx only-allow pnpm",
     "husky:init": "husky install",
     "lint": "xo --fix",
+    "clean": "rimraf build/",
     "build": "swc src/ -d build/",
     "start": "node build/index.js",
-    "dev": "run-s build start"
+    "dev": "run-s clean build start"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",
@@ -50,6 +51,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "prisma": "^4.1.1",
+    "rimraf": "^3.0.2",
     "tsc-files": "^1.1.3",
     "type-fest": "^2.18.0",
     "typescript": "^4.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ specifiers:
   prettier: ^2.7.1
   prisma: ^4.1.1
   reflect-metadata: ^0.1.13
+  rimraf: ^3.0.2
   tsc-files: ^1.1.3
   type-fest: ^2.18.0
   typescript: ^4.7.4
@@ -59,6 +60,7 @@ devDependencies:
   npm-run-all: 4.1.5
   prettier: 2.7.1
   prisma: 4.1.1
+  rimraf: 3.0.2
   tsc-files: 1.1.3_typescript@4.7.4
   type-fest: 2.18.0
   typescript: 4.7.4

--- a/src/lib/tron-client.ts
+++ b/src/lib/tron-client.ts
@@ -67,7 +67,7 @@ export class TronClient extends Client {
             // Fetch all guilds before loading commands
             await this.guilds.fetch();
 
-            await this.stores.get("commands").register();
+            await this.stores.get("commands").registerAll();
         });
 
         this.on("interactionCreate", async (interaction) => {


### PR DESCRIPTION
This PR adds a feature that unregisters commands in the API when they are deleted from the file system.

It also includes a renaming of a few methods in the `CommandStore` to get rid of the "command" suffix and a new build step to clean the `build/` directory so that the file deletion is propagated correctly.