### PR TITLE
feat: add custom events

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -60,10 +60,13 @@ export class TronClient extends Client {
 
         // Register stores
         this.logger.debug("Initializing store registry...");
-        this.stores = new StoreRegistry();
+        this.stores = new StoreRegistry(this.container);
         this.stores.register(new SlashCommandStore({ container: this.container, client: this }));
         this.stores.register(new ListenerStore({ container: this.container, client: this }));
         this.stores.registerPath(fileURLToPath(new URL("../", import.meta.url)));
+
+        // Bind store registry to the container
+        this.container.bind(StoreRegistry).toConstantValue(this.stores);
     }
 
     public override async login(token?: string): Promise<string> {

--- a/src/lib/structures/bases/slash-command.ts
+++ b/src/lib/structures/bases/slash-command.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+    AutocompleteFocusedOption,
     AutocompleteInteraction,
     Awaitable,
     ChatInputCommandInteraction,
@@ -24,14 +25,13 @@ export abstract class SlashCommand {
     public abstract description: string;
     public abstract options: readonly SlashCommandOptionData[];
 
-    public autocomplete?<T extends this>(
+    public autocomplete?(
         interaction: AutocompleteInteraction,
-        focused: string,
-        options: InferSlashCommandOptionsType<T>
+        focused: AutocompleteFocusedOption
     ): Awaitable<unknown>;
 
-    public abstract execute<T extends this>(
+    public abstract execute(
         interaction: ChatInputCommandInteraction,
-        options: InferSlashCommandOptionsType<T>
+        options: InferSlashCommandOptionsType<this>
     ): Awaitable<unknown>;
 }

--- a/src/lib/structures/bases/slash-command.ts
+++ b/src/lib/structures/bases/slash-command.ts
@@ -7,14 +7,14 @@
 import type {
     AutocompleteInteraction,
     Awaitable,
-    CommandInteraction,
+    ChatInputCommandInteraction,
     PermissionResolvable
 } from "discord.js";
-import { Injectable } from "~/lib/decorators/injectable.js";
 import type {
     InferSlashCommandOptionsType,
     SlashCommandOptionData
 } from "~/lib/types/slash-command-options.js";
+import { Injectable } from "~/lib/decorators/injectable.js";
 
 @Injectable
 export abstract class SlashCommand {
@@ -31,7 +31,7 @@ export abstract class SlashCommand {
     ): Awaitable<unknown>;
 
     public abstract execute<T extends this>(
-        interaction: CommandInteraction,
+        interaction: ChatInputCommandInteraction,
         options: InferSlashCommandOptionsType<T>
     ): Awaitable<unknown>;
 }

--- a/src/lib/structures/bases/slash-command.ts
+++ b/src/lib/structures/bases/slash-command.ts
@@ -4,7 +4,12 @@
  * MIT Licensed
  */
 
-import type { AutocompleteInteraction, Awaitable, PermissionResolvable } from "discord.js";
+import type {
+    AutocompleteInteraction,
+    Awaitable,
+    CommandInteraction,
+    PermissionResolvable
+} from "discord.js";
 import { Injectable } from "~/lib/decorators/injectable.js";
 import type {
     InferSlashCommandOptionsType,
@@ -25,5 +30,8 @@ export abstract class SlashCommand {
         options: InferSlashCommandOptionsType<T>
     ): Awaitable<unknown>;
 
-    public abstract execute<T extends this>(options: InferSlashCommandOptionsType<T>): Awaitable<unknown>;
+    public abstract execute<T extends this>(
+        interaction: CommandInteraction,
+        options: InferSlashCommandOptionsType<T>
+    ): Awaitable<unknown>;
 }

--- a/src/lib/structures/stores/slash-command-store.ts
+++ b/src/lib/structures/stores/slash-command-store.ts
@@ -14,15 +14,17 @@ import type {
     ChatInputApplicationCommandData,
     ChatInputCommandInteraction
 } from "discord.js";
-import { ApplicationCommandOptionType, Collection } from "discord.js";
+import {
+    ApplicationCommandOptionType,
+    AutocompleteInteraction,
+    Collection,
+    CommandInteractionOptionResolver
+} from "discord.js";
 import type { interfaces } from "inversify";
 import type { FileMetadata, NamedStoreOptions } from "~/lib/structures/store.js";
 import { Store } from "~/lib/structures/store.js";
 import { SlashCommand } from "~/lib/structures/bases/slash-command.js";
-import type {
-    SlashCommandOptionData,
-    SlashCommandOptionResolver
-} from "~/lib/types/slash-command-options.js";
+import type { SlashCommandOptionData } from "~/lib/types/slash-command-options.js";
 import { SLASH_COMMAND_OPTIONS_TAG } from "~/lib/utils/constants.js";
 import { isSubcommandData, isSubcommandGroupData } from "~/lib/utils/interactions.js";
 
@@ -33,7 +35,7 @@ export class SlashCommandStore extends Store<SlashCommand> {
         super(SlashCommand as any, { ...options, name: "commands" });
     }
 
-    public get(interaction: ChatInputCommandInteraction): SlashCommand {
+    public get(interaction: ChatInputCommandInteraction | AutocompleteInteraction): SlashCommand {
         return this.container.getTagged<SlashCommand>(
             interaction.commandName,
             SLASH_COMMAND_OPTIONS_TAG,
@@ -114,7 +116,7 @@ export class SlashCommandStore extends Store<SlashCommand> {
                     .getCustomTags()!
                     .find(
                         (tags) => tags.key === SLASH_COMMAND_OPTIONS_TAG
-                    )! as interfaces.Metadata<SlashCommandOptionResolver>;
+                    )! as interfaces.Metadata<CommandInteractionOptionResolver>;
 
                 if (!optionsResolver.getSubcommandGroup() && optionsResolver.getSubcommand())
                     return commandOptions.some(

--- a/src/lib/structures/stores/slash-command-store.ts
+++ b/src/lib/structures/stores/slash-command-store.ts
@@ -33,6 +33,14 @@ export class SlashCommandStore extends Store<SlashCommand> {
         super(SlashCommand as any, { ...options, name: "commands" });
     }
 
+    public get(interaction: ChatInputCommandInteraction): SlashCommand {
+        return this.container.getTagged<SlashCommand>(
+            interaction.commandName,
+            SLASH_COMMAND_OPTIONS_TAG,
+            interaction.options
+        );
+    }
+
     public async registerAll(): Promise<void> {
         // Early escape when application is not properly loaded.
         if (!this.client.application) return;

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -1,0 +1,23 @@
+/*
+ * Tron 3
+ * Copyright (c) 2022 Krzysztof Saczuk <zakku@zakku.eu>.
+ * MIT Licensed
+ */
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+import type { AutocompleteInteraction, CommandInteraction, ContextMenuCommandInteraction } from "discord.js";
+
+export enum TronEvents {
+    PossibleChatInputCommand = "possibleChatInputCommand",
+    PossibleContextMenuCommand = "possibleContextMenuCommand",
+    PossibleAutocompleteInteraction = "possibleAutocompleteInteraction"
+}
+
+declare module "discord.js" {
+    interface ClientEvents {
+        [TronEvents.PossibleChatInputCommand]: [interaction: CommandInteraction];
+        [TronEvents.PossibleContextMenuCommand]: [interaction: ContextMenuCommandInteraction];
+        [TronEvents.PossibleAutocompleteInteraction]: [interaction: AutocompleteInteraction];
+    }
+}

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -6,7 +6,11 @@
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
-import type { AutocompleteInteraction, CommandInteraction, ContextMenuCommandInteraction } from "discord.js";
+import type {
+    AutocompleteInteraction,
+    ChatInputCommandInteraction,
+    ContextMenuCommandInteraction
+} from "discord.js";
 
 export enum TronEvents {
     PossibleChatInputCommand = "possibleChatInputCommand",
@@ -16,7 +20,7 @@ export enum TronEvents {
 
 declare module "discord.js" {
     interface ClientEvents {
-        [TronEvents.PossibleChatInputCommand]: [interaction: CommandInteraction];
+        [TronEvents.PossibleChatInputCommand]: [interaction: ChatInputCommandInteraction];
         [TronEvents.PossibleContextMenuCommand]: [interaction: ContextMenuCommandInteraction];
         [TronEvents.PossibleAutocompleteInteraction]: [interaction: AutocompleteInteraction];
     }

--- a/src/lib/types/slash-command-options.ts
+++ b/src/lib/types/slash-command-options.ts
@@ -20,7 +20,7 @@ export type SlashCommandOptionData = Exclude<
     ApplicationCommandSubCommandData | ApplicationCommandSubGroupData
 >;
 
-interface SlashCommandOptionTypeMap {
+export interface SlashCommandOptionTypeMap {
     [ApplicationCommandOptionType.String]: string;
     [ApplicationCommandOptionType.Number]: number;
     [ApplicationCommandOptionType.Integer]: number;
@@ -30,11 +30,11 @@ interface SlashCommandOptionTypeMap {
     [ApplicationCommandOptionType.Role]: Role;
 }
 
-type ConvertSlashCommandOptionTypeToDataType<T> = T extends keyof SlashCommandOptionTypeMap
+export type ConvertSlashCommandOptionTypeToDataType<T> = T extends keyof SlashCommandOptionTypeMap
     ? SlashCommandOptionTypeMap[T]
     : never;
 
-type ConvertSlashCommandOptionDataToPropertyType<T> = T extends {
+export type ConvertSlashCommandOptionDataToPropertyType<T> = T extends {
     name: infer Name;
     type: infer Type;
     required?: infer Required;
@@ -44,7 +44,10 @@ type ConvertSlashCommandOptionDataToPropertyType<T> = T extends {
         : { [K in Name & string]?: ConvertSlashCommandOptionTypeToDataType<Type> }
     : never;
 
-type ConvertSlashCommandOptionDataArrayToPropertyUnionType<T> = T extends readonly [infer Head, ...infer Tail]
+export type ConvertSlashCommandOptionDataArrayToPropertyUnionType<T> = T extends readonly [
+    infer Head,
+    ...infer Tail
+]
     ? ConvertSlashCommandOptionDataToPropertyType<Head> &
           ConvertSlashCommandOptionDataArrayToPropertyUnionType<Tail>
     : T extends readonly [infer Head]

--- a/src/lib/types/slash-command-options.ts
+++ b/src/lib/types/slash-command-options.ts
@@ -11,6 +11,7 @@ import type {
     ApplicationCommandSubCommandData,
     ApplicationCommandSubGroupData,
     Channel,
+    ChatInputCommandInteraction,
     Role,
     User
 } from "discord.js";
@@ -19,6 +20,8 @@ export type SlashCommandOptionData = Exclude<
     ApplicationCommandOptionData,
     ApplicationCommandSubCommandData | ApplicationCommandSubGroupData
 >;
+
+export type SlashCommandOptionResolver = ChatInputCommandInteraction["options"];
 
 export interface SlashCommandOptionTypeMap {
     [ApplicationCommandOptionType.String]: string;

--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -1,0 +1,7 @@
+/*
+ * Tron 3
+ * Copyright (c) 2022 Krzysztof Saczuk <zakku@zakku.eu>.
+ * MIT Licensed
+ */
+
+export const SLASH_COMMAND_OPTIONS_TAG = Symbol("SLASH_COMMAND_OPTIONS");

--- a/src/lib/utils/interactions.ts
+++ b/src/lib/utils/interactions.ts
@@ -1,0 +1,72 @@
+/*
+ * Tron 3
+ * Copyright (c) 2022 Krzysztof Saczuk <zakku@zakku.eu>.
+ * MIT Licensed
+ */
+
+import type {
+    ApplicationCommandOptionData,
+    ApplicationCommandSubCommandData,
+    ApplicationCommandSubGroupData
+} from "discord.js";
+import { ApplicationCommandOptionType } from "discord.js";
+import type {
+    ConvertSlashCommandOptionTypeToDataType,
+    SlashCommandOptionResolver
+} from "~/lib/types/slash-command-options.js";
+
+export const isSubcommandData = (value: unknown): value is ApplicationCommandSubCommandData => {
+    return (
+        typeof value === "object" &&
+        typeof (value as ApplicationCommandOptionData).type !== "undefined" &&
+        (value as ApplicationCommandOptionData).type === ApplicationCommandOptionType.Subcommand
+    );
+};
+
+export const isSubcommandGroupData = (value: unknown): value is ApplicationCommandSubGroupData => {
+    return (
+        typeof value === "object" &&
+        typeof (value as ApplicationCommandOptionData).type !== "undefined" &&
+        (value as ApplicationCommandOptionData).type === ApplicationCommandOptionType.SubcommandGroup
+    );
+};
+
+export const getTypedOption = <T extends ApplicationCommandOptionType>(
+    resolver: SlashCommandOptionResolver,
+    name: string,
+    type: T,
+    required = false
+    // eslint-disable-next-line @typescript-eslint/ban-types
+): ConvertSlashCommandOptionTypeToDataType<T> | null => {
+    let value;
+
+    switch (type) {
+        case ApplicationCommandOptionType.String:
+            value = resolver.getString(name, required);
+            break;
+        case ApplicationCommandOptionType.Integer:
+            value = resolver.getInteger(name, required);
+            break;
+        case ApplicationCommandOptionType.Number:
+            value = resolver.getNumber(name, required);
+            break;
+        case ApplicationCommandOptionType.Boolean:
+            value = resolver.getBoolean(name, required);
+            break;
+        case ApplicationCommandOptionType.User:
+            value = resolver.getUser(name, required);
+            break;
+        case ApplicationCommandOptionType.Channel:
+            value = resolver.getChannel(name, required);
+            break;
+        case ApplicationCommandOptionType.Role:
+            value = resolver.getRole(name, required);
+            break;
+        default:
+            value = null;
+            break;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    return value as ConvertSlashCommandOptionTypeToDataType<T> | null;
+};

--- a/src/listeners/core-interaction-create.ts
+++ b/src/listeners/core-interaction-create.ts
@@ -22,6 +22,7 @@ export class CoreInteractionCreate extends Listener<Events.InteractionCreate> {
 
     async execute(interaction: Interaction): Promise<void> {
         // TODO: Handle message components and modals via interaction handlers
+        // TODO: Handle context menus via context menu handlers
 
         if (interaction.isChatInputCommand())
             this.client.emit(TronEvents.PossibleChatInputCommand, interaction);

--- a/src/listeners/core-interaction-create.ts
+++ b/src/listeners/core-interaction-create.ts
@@ -4,17 +4,31 @@
  * MIT Licensed
  */
 
-import { Events, Interaction } from "discord.js";
+import { Client, Events, Interaction } from "discord.js";
 
 import { Listener } from "~/lib/structures/bases/listener.js";
+import { TronEvents } from "~/lib/types/events.js";
+import { Logger } from "~/lib/utils/logger.js";
+import { Injectable } from "~/lib/decorators/injectable.js";
 
+@Injectable
 export class CoreInteractionCreate extends Listener<Events.InteractionCreate> {
     public readonly once = false;
     public readonly event = Events.InteractionCreate;
 
-    async execute(interaction: Interaction): Promise<void> {
-        console.log(interaction);
+    constructor(public client: Client, public logger: Logger) {
+        super();
+    }
 
-        if (interaction.isChatInputCommand()) await interaction.reply("TEMP");
+    async execute(interaction: Interaction): Promise<void> {
+        // TODO: Handle message components and modals via interaction handlers
+
+        if (interaction.isChatInputCommand())
+            this.client.emit(TronEvents.PossibleChatInputCommand, interaction);
+        else if (interaction.isContextMenuCommand())
+            this.client.emit(TronEvents.PossibleContextMenuCommand, interaction);
+        else if (interaction.isAutocomplete())
+            this.client.emit(TronEvents.PossibleAutocompleteInteraction, interaction);
+        else this.logger.warn("Unhandled interaction type %s", interaction.constructor.name);
     }
 }

--- a/src/listeners/core-possible-autocomplete-interaction.ts
+++ b/src/listeners/core-possible-autocomplete-interaction.ts
@@ -1,0 +1,29 @@
+/*
+ * Tron 3
+ * Copyright (c) 2022 Krzysztof Saczuk <zakku@zakku.eu>.
+ * MIT Licensed
+ */
+
+import type { AutocompleteInteraction } from "discord.js";
+import { Listener } from "~/lib/structures/bases/listener.js";
+import { TronEvents } from "~/lib/types/events.js";
+import { Injectable } from "~/lib/decorators/injectable.js";
+import { SlashCommandStore } from "~/lib/structures/stores/slash-command-store.js";
+
+@Injectable
+export class CorePossibleAutocompleteInteraction extends Listener<TronEvents.PossibleAutocompleteInteraction> {
+    readonly once = false;
+    readonly event = TronEvents.PossibleAutocompleteInteraction;
+
+    constructor(public store: SlashCommandStore) {
+        super();
+    }
+
+    async execute(interaction: AutocompleteInteraction): Promise<void> {
+        const command = this.store.get(interaction);
+        const { autocomplete: autocompleteMethod } = command;
+        const { options: optionsResolver } = interaction;
+
+        await autocompleteMethod?.call(command, interaction, optionsResolver.getFocused(true));
+    }
+}

--- a/src/listeners/core-possible-chat-input-command.ts
+++ b/src/listeners/core-possible-chat-input-command.ts
@@ -1,0 +1,43 @@
+/*
+ * Tron 3
+ * Copyright (c) 2022 Krzysztof Saczuk <zakku@zakku.eu>.
+ * MIT Licensed
+ */
+
+import type { ChatInputCommandInteraction } from "discord.js";
+import { Listener } from "~/lib/structures/bases/listener.js";
+import { TronEvents } from "~/lib/types/events.js";
+import { Injectable } from "~/lib/decorators/injectable.js";
+import { SlashCommandStore } from "~/lib/structures/stores/slash-command-store.js";
+import { getTypedOption } from "~/lib/utils/interactions.js";
+import type { InferSlashCommandOptionsType } from "~/lib/types/slash-command-options.js";
+import type { SlashCommand } from "~/lib/structures/bases/slash-command.js";
+
+@Injectable
+export class CorePossibleChatInputCommand extends Listener<TronEvents.PossibleChatInputCommand> {
+    readonly once = false;
+    readonly event = TronEvents.PossibleChatInputCommand;
+
+    constructor(private readonly store: SlashCommandStore) {
+        super();
+    }
+
+    async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+        const command = this.store.get(interaction);
+        const { options: commandOptions, execute: executeMethod } = command;
+        const { options: optionsResolver } = interaction;
+
+        const resolvedOptions = Object.fromEntries(
+            commandOptions.map((option) => [
+                option.name,
+                getTypedOption(optionsResolver, option.name, option.type)
+            ])
+        );
+
+        await executeMethod.call(
+            command,
+            interaction,
+            resolvedOptions as InferSlashCommandOptionsType<SlashCommand>
+        );
+    }
+}


### PR DESCRIPTION
This PR adds support for custom events and implements usages of `PossibleChatInputCommand` and `PossibleAutocompleteInteraction` events.