### PR TITLE
fix(client): `ClientOptions` type being forced as normal import

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -7,7 +7,10 @@
 import { fileURLToPath, URL } from "node:url";
 import type { interfaces } from "inversify";
 import { Container } from "inversify";
-import { Client, ClientOptions } from "discord.js";
+/* eslint-disable @typescript-eslint/consistent-type-imports */
+import type { ClientOptions } from "discord.js";
+import { Client } from "discord.js";
+/* eslint-enable @typescript-eslint/consistent-type-imports */
 import { LABEL } from "@zakku/winston-logs";
 import { Injectable } from "~/lib/decorators/injectable.js";
 import { Logger } from "~/lib/utils/logger.js";


### PR DESCRIPTION
This PR fixes a bug that existed because ESLint forced `ClientOptions` and `Client` imports to be combined into a single import but `ClientOptions` is a type and can't be found at runtime which resulted in failed builds.